### PR TITLE
Send sample number icon data to PathwayMapper

### DIFF
--- a/package.json
+++ b/package.json
@@ -196,7 +196,7 @@
     "oncokb-ts-api-client": "^1.1.3",
     "oncoprintjs": "4.2.3",
     "parameter-validator": "^1.0.2",
-    "pathway-mapper": "github:iVis-at-Bilkent/pathway-mapper#ad0e9e02ce769fdc7afebaac1b82466a8cbe8c46",
+    "pathway-mapper": "github:iVis-at-Bilkent/pathway-mapper#e118ca6ac3b8dd532a992e9fdf625c3c00fadd98",
     "pdfobject": "^2.0.201604172",
     "pegjs": "^0.10.0",
     "plotly.js": "^1.42.5",

--- a/src/pages/patientView/PatientViewPage.tsx
+++ b/src/pages/patientView/PatientViewPage.tsx
@@ -1547,6 +1547,7 @@ export default class PatientViewPage extends React.Component<
                                         .mergedMutationDataIncludingUncalledFilteredByGene ? (
                                         <PatientViewPathwayMapper
                                             store={this.patientViewPageStore}
+                                            sampleManager={sampleManager}
                                         />
                                     ) : (
                                         <LoadingIndicator

--- a/src/pages/patientView/pathwayMapper/PatientViewPathwayMapper.tsx
+++ b/src/pages/patientView/pathwayMapper/PatientViewPathwayMapper.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { PatientViewPageStore } from '../clinicalInformation/PatientViewPageStore';
+import SampleManager from '../SampleManager';
 import PathwayMapperTable, {
     IPathwayMapperTable,
     IPathwayMapperTableColumnType,
@@ -19,11 +20,10 @@ import PathwayMapper, { ICBioData } from 'pathway-mapper';
 import 'pathway-mapper/dist/base.css';
 import 'cytoscape-panzoom/cytoscape.js-panzoom.css';
 import 'cytoscape-navigator/cytoscape.js-navigator.css';
-import SampleManager from '../SampleManager';
 
 interface IPatientViewPathwayMapperProps {
     store: PatientViewPageStore;
-    sampleManager: SampleManager | null;
+    sampleManager?: SampleManager;
 }
 
 const DEFAULT_RULESET_PARAMS = getGeneticTrackRuleSetParams(true, true, true);
@@ -107,16 +107,15 @@ export default class PatientViewPathwayMapper extends React.Component<
             return null;
         }
 
-        var sampleIconData = {
-            sampleIndex: {},
-            sampleColors: {},
-        };
-        if (this.props.sampleManager) {
-            sampleIconData = {
-                sampleIndex: this.props.sampleManager.sampleIndex,
-                sampleColors: this.props.sampleManager.sampleColors,
-            };
-        }
+        const sampleIconData = this.props.sampleManager
+            ? {
+                  sampleIndex: this.props.sampleManager.sampleIndex,
+                  sampleColors: this.props.sampleManager.sampleColors,
+              }
+            : {
+                  sampleIndex: {},
+                  sampleColors: {},
+              };
 
         return (
             <div className="pathwayMapper">

--- a/src/pages/patientView/pathwayMapper/PatientViewPathwayMapper.tsx
+++ b/src/pages/patientView/pathwayMapper/PatientViewPathwayMapper.tsx
@@ -19,9 +19,11 @@ import PathwayMapper, { ICBioData } from 'pathway-mapper';
 import 'pathway-mapper/dist/base.css';
 import 'cytoscape-panzoom/cytoscape.js-panzoom.css';
 import 'cytoscape-navigator/cytoscape.js-navigator.css';
+import SampleManager from '../SampleManager';
 
 interface IPatientViewPathwayMapperProps {
     store: PatientViewPageStore;
+    sampleManager: SampleManager | null;
 }
 
 const DEFAULT_RULESET_PARAMS = getGeneticTrackRuleSetParams(true, true, true);
@@ -104,6 +106,18 @@ export default class PatientViewPathwayMapper extends React.Component<
         if (!this.PathwayMapperComponent) {
             return null;
         }
+
+        var sampleIconData = {
+            sampleIndex: {},
+            sampleColors: {},
+        };
+        if (this.props.sampleManager) {
+            sampleIconData = {
+                sampleIndex: this.props.sampleManager.sampleIndex,
+                sampleColors: this.props.sampleManager.sampleColors,
+            };
+        }
+
         return (
             <div className="pathwayMapper">
                 <div
@@ -119,6 +133,7 @@ export default class PatientViewPathwayMapper extends React.Component<
                             isCollaborative={false}
                             genes={this.queryGenes}
                             cBioAlterationData={this.alterationFrequencyData}
+                            sampleIconData={sampleIconData}
                             tableComponent={this.renderTable}
                             patientView={true}
                             //message banner patch will be removed

--- a/yarn.lock
+++ b/yarn.lock
@@ -16664,9 +16664,9 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
-"pathway-mapper@github:iVis-at-Bilkent/pathway-mapper#ad0e9e02ce769fdc7afebaac1b82466a8cbe8c46":
+"pathway-mapper@github:iVis-at-Bilkent/pathway-mapper#e118ca6ac3b8dd532a992e9fdf625c3c00fadd98":
   version "2.0.3"
-  resolved "https://codeload.github.com/iVis-at-Bilkent/pathway-mapper/tar.gz/ad0e9e02ce769fdc7afebaac1b82466a8cbe8c46"
+  resolved "https://codeload.github.com/iVis-at-Bilkent/pathway-mapper/tar.gz/e118ca6ac3b8dd532a992e9fdf625c3c00fadd98"
   dependencies:
     "@datastructures-js/max-heap" "^2.0.0"
     autobind-decorator "^2.4.0"


### PR DESCRIPTION
Send sample index and color information to PatientViewPathwayMapper component so that the sample number icons can be rendered on the PathwayMapper side.