### PR TITLE
Fix tests and update PathwayMapper

### DIFF
--- a/end-to-end-test/remote/specs/core/screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/screenshot.spec.js
@@ -165,8 +165,7 @@ function runResultsTestSuite(prefix, options = {}) {
     it(`${prefix} pathwaymapper tab`, function() {
         browser.click('a.tabAnchor_pathways');
         browser.waitForVisible('#cy', 10000);
-        browser.waitForExist('.Toastify__toast', 4000);
-        browser.waitUntil(() => !$('.Toastify__toast').isExisting());
+        browser.waitForExist('#pathway-mapper-message-box', 4000);
         var res = browser.checkElement('[data-test="pathwayMapperTabDiv"]', {
             hide: ['.qtip', '.__react_component_tooltip', '.rc-tooltip'],
         });

--- a/end-to-end-test/remote/specs/core/screenshot.spec.js
+++ b/end-to-end-test/remote/specs/core/screenshot.spec.js
@@ -165,7 +165,7 @@ function runResultsTestSuite(prefix, options = {}) {
     it(`${prefix} pathwaymapper tab`, function() {
         browser.click('a.tabAnchor_pathways');
         browser.waitForVisible('#cy', 10000);
-        browser.waitForExist('#pathway-mapper-message-box', 4000);
+        browser.waitForExist('div[data-test="pathwayMapperMessageBox"]', 4000);
         var res = browser.checkElement('[data-test="pathwayMapperTabDiv"]', {
             hide: ['.qtip', '.__react_component_tooltip', '.rc-tooltip'],
         });

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "oncokb-ts-api-client": "^1.1.3",
     "oncoprintjs": "4.2.4",
     "parameter-validator": "^1.0.2",
-    "pathway-mapper": "github:iVis-at-Bilkent/pathway-mapper#0e087998b4c97e1bf6a3887632b005e5f3d95e13",
+    "pathway-mapper": "github:iVis-at-Bilkent/pathway-mapper#6875fd9ee1f4a24efefbc19baabf5a0c4d58ea42",
     "pdfobject": "^2.0.201604172",
     "pegjs": "^0.10.0",
     "plotly.js": "^1.42.5",

--- a/package.json
+++ b/package.json
@@ -200,7 +200,7 @@
     "oncokb-ts-api-client": "^1.1.3",
     "oncoprintjs": "4.2.4",
     "parameter-validator": "^1.0.2",
-    "pathway-mapper": "github:iVis-at-Bilkent/pathway-mapper#43564adb53cafb9e1b1018c9d5aaf19ffc0d18e7",
+    "pathway-mapper": "github:iVis-at-Bilkent/pathway-mapper#0e087998b4c97e1bf6a3887632b005e5f3d95e13",
     "pdfobject": "^2.0.201604172",
     "pegjs": "^0.10.0",
     "plotly.js": "^1.42.5",

--- a/src/pages/patientView/pathwayMapper/PatientViewPathwayMapper.tsx
+++ b/src/pages/patientView/pathwayMapper/PatientViewPathwayMapper.tsx
@@ -138,8 +138,6 @@ export default class PatientViewPathwayMapper extends React.Component<
                             sampleIconData={this.sampleIconData}
                             tableComponent={this.renderTable}
                             patientView={true}
-                            // TODO PathwayMapper crashes if message banner is not provided, need to be fixed on PM side
-                            messageBanner={() => null}
                         />
                     </Row>
                 </div>

--- a/src/shared/lib/pathwayMapper/PathwayMapperMessageBox.tsx
+++ b/src/shared/lib/pathwayMapper/PathwayMapperMessageBox.tsx
@@ -12,7 +12,7 @@ const PathwayMapperMessageBox: React.FunctionComponent<PathwayMapperMessageBoxPr
     const isWarningMessage = message !== props.loadingMessage;
     return (
         <div
-            id="pathway-mapper-message-box"
+            data-test="pathwayMapperMessageBox"
             className={
                 'alert ' +
                 (isWarningMessage ? 'alert-warning' : 'alert-success')

--- a/src/shared/lib/pathwayMapper/PathwayMapperMessageBox.tsx
+++ b/src/shared/lib/pathwayMapper/PathwayMapperMessageBox.tsx
@@ -12,6 +12,7 @@ const PathwayMapperMessageBox: React.FunctionComponent<PathwayMapperMessageBoxPr
     const isWarningMessage = message !== props.loadingMessage;
     return (
         <div
+            id="pathway-mapper-message-box"
             className={
                 'alert ' +
                 (isWarningMessage ? 'alert-warning' : 'alert-success')

--- a/yarn.lock
+++ b/yarn.lock
@@ -16738,9 +16738,9 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
-"pathway-mapper@github:iVis-at-Bilkent/pathway-mapper#0e087998b4c97e1bf6a3887632b005e5f3d95e13":
+"pathway-mapper@github:iVis-at-Bilkent/pathway-mapper#6875fd9ee1f4a24efefbc19baabf5a0c4d58ea42":
   version "2.0.3"
-  resolved "https://codeload.github.com/iVis-at-Bilkent/pathway-mapper/tar.gz/0e087998b4c97e1bf6a3887632b005e5f3d95e13"
+  resolved "https://codeload.github.com/iVis-at-Bilkent/pathway-mapper/tar.gz/6875fd9ee1f4a24efefbc19baabf5a0c4d58ea42"
   dependencies:
     "@datastructures-js/max-heap" "^2.0.0"
     autobind-decorator "^2.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16738,9 +16738,9 @@ pathval@^1.1.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.0.tgz#b942e6d4bde653005ef6b71361def8727d0645e0"
   integrity sha1-uULm1L3mUwBe9rcTYd74cn0GReA=
 
-"pathway-mapper@github:iVis-at-Bilkent/pathway-mapper#43564adb53cafb9e1b1018c9d5aaf19ffc0d18e7":
+"pathway-mapper@github:iVis-at-Bilkent/pathway-mapper#0e087998b4c97e1bf6a3887632b005e5f3d95e13":
   version "2.0.3"
-  resolved "https://codeload.github.com/iVis-at-Bilkent/pathway-mapper/tar.gz/43564adb53cafb9e1b1018c9d5aaf19ffc0d18e7"
+  resolved "https://codeload.github.com/iVis-at-Bilkent/pathway-mapper/tar.gz/0e087998b4c97e1bf6a3887632b005e5f3d95e13"
   dependencies:
     "@datastructures-js/max-heap" "^2.0.0"
     autobind-decorator "^2.4.0"


### PR DESCRIPTION
Fix e2e tests for toast in PatientView, which was replaced with a message banner. Check for existence of banner instead. Remove a condition in a test that was waiting for toast to disappear, since that functionality was replaced with a message banner witha 'close' button. Resolve https://github.com/cBioPortal/cbioportal-frontend/pull/3458#issuecomment-742709284.

Update PathwayMapper to latest version where the PatientView help modal is better spaced out (removed breaklines). See https://github.com/iVis-at-Bilkent/pathway-mapper/commit/0e087998b4c97e1bf6a3887632b005e5f3d95e13.

Remove messageBanner property from PathwayMapperComponent of PatientViewPathwayMapper since it has become an optional property.
